### PR TITLE
Handle Firefox binary configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Cada camada depende apenas de contratos definidos em níveis superiores, permiti
 ## Pré-requisitos
 
 1. **Python 3.10+**
-2. **Firefox** instalado.
+2. **Firefox** instalado (caso esteja em um caminho não padrão, informe o executável pela variável de ambiente `FIREFOX_BINARY`).
 3. **Geckodriver** compatível com a versão do Firefox disponível no `PATH` do sistema. Consulte a [documentação oficial](https://firefox-source-docs.mozilla.org/testing/geckodriver/) para download.
 4. (Opcional) Ambiente virtual Python para isolar dependências.
 

--- a/src/gptpar/infrastructure/browser/selenium_driver_factory.py
+++ b/src/gptpar/infrastructure/browser/selenium_driver_factory.py
@@ -1,21 +1,98 @@
 from __future__ import annotations
 
+import os
+import shutil
 from pathlib import Path
 from typing import Optional
 
 from selenium import webdriver
+from selenium.common.exceptions import InvalidArgumentException
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 
 
-def create_firefox_driver(profile_path: Optional[Path] = None, headless: bool = False) -> webdriver.Firefox:
-    """Create a configured Firefox WebDriver instance."""
+def create_firefox_driver(
+    profile_path: Optional[Path] = None,
+    headless: bool = False,
+    firefox_binary: Optional[Path] = None,
+) -> webdriver.Firefox:
+    """Create a configured Firefox WebDriver instance.
+
+    Parameters
+    ----------
+    profile_path:
+        Optional path to an existing Firefox profile directory.
+    headless:
+        Whether the browser should run in headless mode.
+    firefox_binary:
+        Explicit path to the Firefox executable. When provided (or when the
+        ``FIREFOX_BINARY``/``FIREFOX_BIN`` environment variables are set), the
+        path is validated before delegating to Selenium to avoid the less
+        helpful ``InvalidArgumentException`` that Selenium would otherwise
+        raise.
+    """
 
     options = FirefoxOptions()
     options.headless = headless
 
+    binary_location = _resolve_firefox_binary(firefox_binary)
+    if binary_location is not None:
+        options.binary_location = str(binary_location)
+
     if profile_path is not None:
         options.profile = str(profile_path)
 
-    driver = webdriver.Firefox(options=options)
+    try:
+        driver = webdriver.Firefox(options=options)
+    except InvalidArgumentException as exc:
+        message = str(exc)
+        if "binary is not a firefox executable" in message.lower():
+            raise RuntimeError(
+                "O caminho configurado para o Firefox não aponta para um executável válido. "
+                "Revise a variável de ambiente FIREFOX_BINARY ou a configuração utilizada."
+            ) from exc
+        raise
+
     driver.maximize_window()
     return driver
+
+
+def _resolve_firefox_binary(explicit_path: Optional[Path]) -> Optional[Path]:
+    """Return a validated Firefox binary path if one was provided.
+
+    The lookup order prioritises the explicit ``firefox_binary`` argument,
+    followed by the ``FIREFOX_BINARY`` and ``FIREFOX_BIN`` environment
+    variables.  Each candidate is validated to ensure that we only forward
+    existing executables to Selenium.
+    """
+
+    candidates: list[tuple[str, Path]] = []
+
+    if explicit_path is not None:
+        candidates.append(("firefox_binary parameter", explicit_path))
+
+    for env_var in ("FIREFOX_BINARY", "FIREFOX_BIN"):
+        env_value = os.environ.get(env_var)
+        if env_value:
+            candidates.append((f"environment variable {env_var}", Path(env_value)))
+
+    for source, raw_path in candidates:
+        resolved_path = _normalise_executable_path(raw_path)
+        if not resolved_path.exists() or not resolved_path.is_file():
+            raise RuntimeError(f"{source} aponta para um caminho inexistente: {resolved_path}")
+        return resolved_path
+
+    return None
+
+
+def _normalise_executable_path(path: Path) -> Path:
+    """Expand user home references and resolve relative executables."""
+
+    expanded = path.expanduser()
+    if expanded.is_absolute():
+        return expanded
+
+    found = shutil.which(str(expanded))
+    if found:
+        return Path(found)
+
+    return expanded

--- a/src/gptpar/interface/gui/main_window.py
+++ b/src/gptpar/interface/gui/main_window.py
@@ -27,6 +27,7 @@ LOGGER = logging.getLogger(__name__)
 class AppConfiguration:
     storage_path: Path
     headless: bool = False
+    firefox_binary: Optional[Path] = None
 
 
 class AppDependencies:
@@ -38,8 +39,12 @@ class AppDependencies:
         self._config = config
 
         repository = JsonMacroRepository(config.storage_path)
-        recorder = SeleniumMacroRecorder(lambda: create_firefox_driver(headless=config.headless))
-        player = SeleniumMacroPlayer(lambda: create_firefox_driver(headless=config.headless))
+        recorder = SeleniumMacroRecorder(
+            lambda: create_firefox_driver(headless=config.headless, firefox_binary=config.firefox_binary)
+        )
+        player = SeleniumMacroPlayer(
+            lambda: create_firefox_driver(headless=config.headless, firefox_binary=config.firefox_binary)
+        )
 
         self.start_recording = StartMacroRecording(recorder)
         self.stop_recording = StopMacroRecording(recorder, repository)

--- a/tests/test_selenium_driver_factory.py
+++ b/tests/test_selenium_driver_factory.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from selenium.common.exceptions import InvalidArgumentException
+
+from gptpar.infrastructure.browser.selenium_driver_factory import create_firefox_driver
+
+
+class DummyDriver:
+    def __init__(self, *_, options=None, **__):
+        self.options = options
+        self.maximised = False
+
+    def maximize_window(self) -> None:  # pragma: no cover - trivial
+        self.maximised = True
+
+
+def test_create_firefox_driver_uses_binary_from_env(monkeypatch, tmp_path):
+    fake_firefox = tmp_path / "firefox"
+    fake_firefox.write_text("#!/bin/sh\necho firefox")
+
+    def fake_constructor(*args, **kwargs):
+        driver = DummyDriver(*args, **kwargs)
+        return driver
+
+    monkeypatch.setenv("FIREFOX_BINARY", str(fake_firefox))
+    monkeypatch.setattr(
+        "gptpar.infrastructure.browser.selenium_driver_factory.webdriver.Firefox", fake_constructor
+    )
+
+    driver = create_firefox_driver()
+
+    assert isinstance(driver, DummyDriver)
+    assert driver.maximised is True
+    assert driver.options._binary_location == str(fake_firefox)
+
+
+def test_create_firefox_driver_invalid_binary_path(monkeypatch, tmp_path):
+    missing_path = tmp_path / "missing-firefox"
+    monkeypatch.setenv("FIREFOX_BINARY", str(missing_path))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        create_firefox_driver()
+
+    assert "FIREFOX_BINARY" in str(excinfo.value)
+
+
+def test_create_firefox_driver_translates_invalid_argument(monkeypatch, tmp_path):
+    fake_firefox = tmp_path / "firefox"
+    fake_firefox.write_text("#!/bin/sh\necho firefox")
+
+    def fake_constructor(*args, **kwargs):
+        raise InvalidArgumentException("binary is not a Firefox executable")
+
+    monkeypatch.setenv("FIREFOX_BINARY", str(fake_firefox))
+    monkeypatch.setattr(
+        "gptpar.infrastructure.browser.selenium_driver_factory.webdriver.Firefox", fake_constructor
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        create_firefox_driver()
+
+    assert "executável válido" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- validate optional Firefox binary paths and surface clearer runtime errors when Selenium cannot launch the browser
- allow configuring the binary through the GUI configuration and document the FIREFOX_BINARY environment variable
- add unit tests covering the driver factory behaviour when different binaries are provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c98dceb0c88320b02b3c1ee8df6ddb